### PR TITLE
Update Image Name Vendor from jboss to redhat

### DIFF
--- a/cluster-controller/image.yaml
+++ b/cluster-controller/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-clustercontroller-openshift
+name: redhat-amqstreams-1/amqstreams10-clustercontroller-openshift
 description: "AMQ Streams image for the Cluster Controller"
 version: "1.0"
 from: jboss/openjdk18-rhel7:1.1

--- a/kafka-base/image.yaml
+++ b/kafka-base/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-kafkabase-openshift
+name: redhat-amqstreams-1/amqstreams10-kafkabase-openshift
 description: "AMQ Streams base image for Kafka and Zookeeper"
 version: "1.0"
 from: jboss/openjdk18-rhel7:1.1

--- a/kafka-connect-s2i/image.yaml
+++ b/kafka-connect-s2i/image.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-kafkaconnects2i-openshift
+name: redhat-amqstreams-1/amqstreams10-kafkaconnects2i-openshift
 description: "AMQ Streams image for Kafka Connect with S2I"
 version: "1.0"
-from: jboss-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0
+from: redhat-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0
 
 labels:
   - name: "com.redhat.component"

--- a/kafka-connect/image.yaml
+++ b/kafka-connect/image.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-kafkaconnect-openshift
+name: redhat-amqstreams-1/amqstreams10-kafkaconnect-openshift
 description: "AMQ Streams image for Kafka Connect"
 version: "1.0"
-from: jboss-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
+from: redhat-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
 
 labels:
   - name: "com.redhat.component"

--- a/kafka/image.yaml
+++ b/kafka/image.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-kafka-openshift
+name: redhat-amqstreams-1/amqstreams10-kafka-openshift
 description: "AMQ Streams image for Kafka"
 version: "1.0"
-from: jboss-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
+from: redhat-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
 
 labels:
   - name: "com.redhat.component"

--- a/templates/cluster-controller.yaml
+++ b/templates/cluster-controller.yaml
@@ -192,7 +192,7 @@ objects:
         serviceAccountName: strimzi-cluster-controller
         containers:
           - name: strimzi-cluster-controller
-            image: jboss-amqstreams-1/amqstreams10-clustercontroller-openshift:1.0
+            image: redhat-amqstreams-1/amqstreams10-clustercontroller-openshift:1.0
             env:
               - name: STRIMZI_CONFIGMAP_LABELS
                 value: ${STRIMZI_CONFIGMAP_LABELS}
@@ -205,15 +205,15 @@ objects:
               - name: STRIMZI_OPERATION_TIMEOUT_MS
                 value: ${STRIMZI_OPERATION_TIMEOUT_MS}
               - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
-                value: jboss-amqstreams-1/amqstreams10-zookeeper-openshift:1.0
+                value: redhat-amqstreams-1/amqstreams10-zookeeper-openshift:1.0
               - name: STRIMZI_DEFAULT_KAFKA_IMAGE
-                value: jboss-amqstreams-1/amqstreams10-kafka-openshift:1.0
+                value: redhat-amqstreams-1/amqstreams10-kafka-openshift:1.0
               - name: STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE
-                value: jboss-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0
+                value: redhat-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0
               - name: STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE
-                value: jboss-amqstreams-1/amqstreams10-kafkaconnects2i-openshift:1.0
+                value: redhat-amqstreams-1/amqstreams10-kafkaconnects2i-openshift:1.0
               - name: STRIMZI_DEFAULT_TOPIC_CONTROLLER_IMAGE
-                value: jboss-amqstreams-1/amqstreams10-topiccontroller-openshift:1.0
+                value: redhat-amqstreams-1/amqstreams10-topiccontroller-openshift:1.0
             livenessProbe:
               httpGet:
                 path: /healthy

--- a/templates/connect-s2i-template.yaml
+++ b/templates/connect-s2i-template.yaml
@@ -78,7 +78,7 @@ objects:
       strimzi.io/type: kafka-connect-s2i
   data:
     nodes: "${INSTANCES}"
-    image: "jboss-amqstreams-1/amqstreams10-kafkaconnects2i-openshift:1.0"
+    image: "redhat-amqstreams-1/amqstreams10-kafkaconnects2i-openshift:1.0"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/templates/connect-template.yaml
+++ b/templates/connect-template.yaml
@@ -77,7 +77,7 @@ objects:
       strimzi.io/type: kafka-connect
   data:
     nodes: "${INSTANCES}"
-    image: "jboss-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0"
+    image: "redhat-amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/templates/ephemeral-template.yaml
+++ b/templates/ephemeral-template.yaml
@@ -66,11 +66,11 @@ objects:
       strimzi.io/kind: cluster
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
-    kafka-image: "jboss-amqstreams-1/amqstreams10-kafka-openshift:1.0"
+    kafka-image: "redhat-amqstreams-1/amqstreams10-kafka-openshift:1.0"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
     zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-image: "jboss-amqstreams-1/amqstreams10-zookeeper-openshift:1.0"
+    zookeeper-image: "redhat-amqstreams-1/amqstreams10-zookeeper-openshift:1.0"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     KAFKA_DEFAULT_REPLICATION_FACTOR: "${KAFKA_DEFAULT_REPLICATION_FACTOR}"

--- a/templates/persistent-template.yaml
+++ b/templates/persistent-template.yaml
@@ -72,11 +72,11 @@ objects:
       strimzi.io/kind: cluster
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
-    kafka-image: "jboss-amqstreams-1/amqstreams10-kafka-openshift:1.0"
+    kafka-image: "redhat-amqstreams-1/amqstreams10-kafka-openshift:1.0"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
     zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-image: "jboss-amqstreams-1/amqstreams10-zookeeper-openshift:1.0"
+    zookeeper-image: "redhat-amqstreams-1/amqstreams10-zookeeper-openshift:1.0"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     KAFKA_DEFAULT_REPLICATION_FACTOR: "${KAFKA_DEFAULT_REPLICATION_FACTOR}"

--- a/templates/topic-controller.yaml
+++ b/templates/topic-controller.yaml
@@ -68,7 +68,7 @@ objects:
         serviceAccountName: strimzi-topic-controller
         containers:
           - name: strimzi-topic-controller
-            image: jboss-amqstreams-1/amqstreams10-topiccontroller-openshift:1.0
+            image: redhat-amqstreams-1/amqstreams10-topiccontroller-openshift:1.0
             env:
               - name: STRIMZI_CONFIGMAP_LABELS
                 value: ${STRIMZI_CONFIGMAP_LABELS}

--- a/topic-controller/image.yaml
+++ b/topic-controller/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-topiccontroller-openshift
+name: redhat-amqstreams-1/amqstreams10-topiccontroller-openshift
 description: "AMQ Streams image for the Topic Controller"
 version: "1.0"
 from: jboss/openjdk18-rhel7:1.1

--- a/zookeeper/image.yaml
+++ b/zookeeper/image.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 
-name: jboss-amqstreams-1/amqstreams10-zookeeper-openshift
+name: redhat-amqstreams-1/amqstreams10-zookeeper-openshift
 description: "AMQ Streams image for Zookeeper"
 version: "1.0"
-from: jboss-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
+from: redhat-amqstreams-1/amqstreams10-kafkabase-openshift:1.0
 
 labels:
   - name: "com.redhat.component"


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

According to Cloud Enablement naming conventions,  the image family name should be prefixed with the vendor associated/responsible for it. In our case that would be "redhat".  

WDYT?