### PR TITLE
Backport upstream examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,16 @@
+PROJECT_NAME=examples
+
+RELEASE_VERSION ?= latest
+RELEASE_PATH ?= ../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
+
+release:
+	mkdir -p $(RELEASE_PATH)
+	cp -r ./install $(RELEASE_PATH)/
+	cp -r ./templates $(RELEASE_PATH)/
+	cp -r ./kafka $(RELEASE_PATH)/
+	cp -r ./kafka-connect $(RELEASE_PATH)/
+	cp -r ./user $(RELEASE_PATH)/
+	cp -r ./topic $(RELEASE_PATH)/
+
+
+.PHONY: all build clean docker_build docker_push docker_tag

--- a/examples/install/cluster-operator/01-ServiceAccount-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/01-ServiceAccount-strimzi-cluster-operator.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi

--- a/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/examples/install/cluster-operator/02-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -1,0 +1,194 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - extensions
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  - deploymentconfigs/status
+  - deploymentconfigs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - builds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+  - update
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  - imagestreams/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update

--- a/examples/install/cluster-operator/02-ClusterRoleBinding-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/02-ClusterRoleBinding-strimzi-cluster-operator.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/cluster-operator/03-ClusterRole-strimzi-kafka-broker.yaml
+++ b/examples/install/cluster-operator/03-ClusterRole-strimzi-kafka-broker.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/examples/install/cluster-operator/03-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
+++ b/examples/install/cluster-operator/03-ClusterRoleBinding-strimzi-cluster-operator-kafka-broker-delegation.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-broker-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-broker
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/cluster-operator/04-ClusterRole-strimzi-entity-operator.yaml
+++ b/examples/install/cluster-operator/04-ClusterRole-strimzi-entity-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete

--- a/examples/install/cluster-operator/04-ClusterRole-strimzi-topic-operator.yaml
+++ b/examples/install/cluster-operator/04-ClusterRole-strimzi-topic-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-entity-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
+++ b/examples/install/cluster-operator/04-ClusterRoleBinding-strimzi-cluster-operator-topic-operator-delegation.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-topic-operator-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: myproject
+roleRef:
+  kind: ClusterRole
+  name: strimzi-topic-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/cluster-operator/04-Crd-kafka.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafka.yaml
@@ -1,0 +1,1248 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkas.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Kafka
+    listKind: KafkaList
+    singular: kafka
+    plural: kafkas
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            kafka:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                image:
+                  type: string
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                    selector:
+                      type: object
+                    size:
+                      type: string
+                    type:
+                      type: string
+                listeners:
+                  type: object
+                  properties:
+                    plain:
+                      type: object
+                      properties: {}
+                    tls:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                authorization:
+                  type: object
+                  properties:
+                    superUsers:
+                      type: array
+                      items:
+                        type: string
+                    type:
+                      type: string
+                config:
+                  type: object
+                rack:
+                  type: object
+                  properties:
+                    topologyKey:
+                      type: string
+                      example: failure-domain.beta.kubernetes.io/zone
+                  required:
+                  - topologyKey
+                brokerRackInitImage:
+                  type: string
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                livenessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                readinessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                jvmOptions:
+                  type: object
+                  properties:
+                    -XX:
+                      type: object
+                    -Xms:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    -Xmx:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                metrics:
+                  type: object
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+              required:
+              - replicas
+              - storage
+              - listeners
+            zookeeper:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                image:
+                  type: string
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                    selector:
+                      type: object
+                    size:
+                      type: string
+                    type:
+                      type: string
+                config:
+                  type: object
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                livenessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                readinessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                jvmOptions:
+                  type: object
+                  properties:
+                    -XX:
+                      type: object
+                    -Xms:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    -Xmx:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                metrics:
+                  type: object
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+              required:
+              - replicas
+              - storage
+            topicOperator:
+              type: object
+              properties:
+                watchedNamespace:
+                  type: string
+                image:
+                  type: string
+                reconciliationIntervalSeconds:
+                  type: integer
+                  minimum: 0
+                zookeeperSessionTimeoutSeconds:
+                  type: integer
+                  minimum: 0
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                topicMetadataMaxAttempts:
+                  type: integer
+                  minimum: 0
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+            entityOperator:
+              type: object
+              properties:
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                userOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+          required:
+          - kafka
+          - zookeeper

--- a/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnect.yaml
@@ -1,0 +1,327 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnect
+    listKind: KafkaConnectList
+    singular: kafkaconnect
+    plural: kafkaconnects
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            image:
+              type: string
+            livenessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+            metrics:
+              type: object
+            authentication:
+              type: object
+              properties:
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
+              required:
+              - certificateAndKey
+            bootstrapServers:
+              type: string
+            config:
+              type: object
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+              required:
+              - trustedCertificates
+          required:
+          - bootstrapServers

--- a/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkaconnects2i.yaml
@@ -1,0 +1,329 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects2is.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnectS2I
+    listKind: KafkaConnectS2IList
+    singular: kafkaconnects2i
+    plural: kafkaconnects2is
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            image:
+              type: string
+            livenessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+            metrics:
+              type: object
+            authentication:
+              type: object
+              properties:
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                type:
+                  type: string
+              required:
+              - certificateAndKey
+            bootstrapServers:
+              type: string
+            config:
+              type: object
+            insecureSourceRepository:
+              type: boolean
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+              required:
+              - trustedCertificates
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+          required:
+          - bootstrapServers

--- a/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkatopic.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    singular: kafkatopic
+    plural: kafkatopics
+    shortNames:
+    - kt
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            partitions:
+              type: integer
+              minimum: 1
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 32767
+            config:
+              type: object
+            topicName:
+              type: string

--- a/examples/install/cluster-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/cluster-operator/04-Crd-kafkauser.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkausers.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaUser
+    listKind: KafkaUserList
+    singular: kafkauser
+    plural: kafkausers
+    shortNames:
+    - ku
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            authentication:
+              type: object
+              properties:
+                type:
+                  type: string
+            authorization:
+              type: object
+              properties:
+                acls:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      host:
+                        type: string
+                      operation:
+                        type: string
+                        enum:
+                        - Read
+                        - Write
+                        - Create
+                        - Delete
+                        - Alter
+                        - Describe
+                        - ClusterAction
+                        - AlterConfigs
+                        - DescribeConfigs
+                        - IdempotentWrite
+                        - All
+                      resource:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          patternType:
+                            type: string
+                            enum:
+                            - literal
+                            - prefix
+                          type:
+                            type: string
+                      type:
+                        type: string
+                        enum:
+                        - allow
+                        - deny
+                    required:
+                    - operation
+                    - resource
+                type:
+                  type: string
+              required:
+              - acls
+          required:
+          - authentication

--- a/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
+++ b/examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: strimzi-cluster-operator
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      containers:
+      - name: strimzi-cluster-operator
+        image: amqstreams-1-beta/amqstreams10-clusteroperator-openshift:1.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: STRIMZI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+          value: "120000"
+        - name: STRIMZI_OPERATION_TIMEOUT_MS
+          value: "300000"
+        - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
+          value: amqstreams-1-beta/amqstreams10-zookeeper-openshift:1.0
+        - name: STRIMZI_DEFAULT_KAFKA_IMAGE
+          value: amqstreams-1-beta/amqstreams10-kafka-openshift:1.0
+        - name: STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE
+          value: amqstreams-1-beta/amqstreams10-kafkaconnect-openshift:1.0
+        - name: STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE
+          value: amqstreams-1-beta/amqstreams10-kafkaconnects2i-openshift:1.0
+        - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+          value: amqstreams-1-beta/amqstreams10-topicoperator-openshift:1.0
+        - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+          value: amqstreams-1-beta/amqstreams10-useroperator-openshift:1.0
+        - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+          value: amqstreams-1-beta/amqstreams10-kafkainit-openshift:1.0
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
+          value: amqstreams-1-beta/amqstreams10-zookeeperstunnel-openshift:1.0
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+          value: amqstreams-1-beta/amqstreams10-kafkastunnel-openshift:1.0
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+          value: amqstreams-1-beta/amqstreams10-entityoperatorstunnel-openshift:1.0
+        - name: STRIMZI_LOG_LEVEL
+          value: INFO
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+  strategy:
+    type: Recreate

--- a/examples/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml
@@ -1,0 +1,12 @@
+##---
+# Source: strimzi-kafka-operator/templates/04-service-account-kafka.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+    chart: strimzi-kafka-operator-0.1.0
+    component: kafka-service-account
+    release: RELEASE-NAME
+    heritage: Tiller

--- a/examples/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/examples/install/topic-operator/03-RoleBinding-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/03-RoleBinding-strimzi-topic-operator.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-topic-operator
+roleRef:
+  kind: Role
+  name: strimzi-topic-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/examples/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    singular: kafkatopic
+    plural: kafkatopics
+    shortNames:
+    - kt
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            partitions:
+              type: integer
+              minimum: 1
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 32767
+            config:
+              type: object
+            topicName:
+              type: string

--- a/examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/examples/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: strimzi-topic-operator
+    spec:
+      serviceAccountName: strimzi-topic-operator
+      containers:
+        - name: strimzi-topic-operator
+          image:  amqstreams-1-beta/amqstreams10-topicoperator-openshift:1.0
+          env:
+            - name: STRIMZI_CONFIGMAP_LABELS
+              value: "strimzi.io/kind=topic"
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: STRIMZI_ZOOKEEPER_CONNECT
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS
+              value: "20000"
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "900000"
+            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS
+              value: "6"
+            - name: STRIMZI_LOG_LEVEL
+              value: INFO
+            - name: STRIMZI_TLS_ENABLED
+              value: "false"
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 100m
+            requests:
+              memory: 96Mi
+              cpu: 100m
+  strategy:
+    type: Recreate

--- a/examples/install/user-operator/01-ServiceAccount-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/01-ServiceAccount-strimzi-user-operator.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi

--- a/examples/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete

--- a/examples/install/user-operator/03-RoleBinding-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/03-RoleBinding-strimzi-user-operator.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-user-operator
+roleRef:
+  kind: Role
+  name: strimzi-user-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/install/user-operator/04-Crd-kafkauser.yaml
+++ b/examples/install/user-operator/04-Crd-kafkauser.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkausers.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaUser
+    listKind: KafkaUserList
+    singular: kafkauser
+    plural: kafkausers
+    shortNames:
+    - ku
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            authentication:
+              type: object
+              properties:
+                type:
+                  type: string
+            authorization:
+              type: object
+              properties:
+                acls:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      host:
+                        type: string
+                      operation:
+                        type: string
+                        enum:
+                        - Read
+                        - Write
+                        - Create
+                        - Delete
+                        - Alter
+                        - Describe
+                        - ClusterAction
+                        - AlterConfigs
+                        - DescribeConfigs
+                        - IdempotentWrite
+                        - All
+                      resource:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          patternType:
+                            type: string
+                            enum:
+                            - literal
+                            - prefix
+                          type:
+                            type: string
+                      type:
+                        type: string
+                        enum:
+                        - allow
+                        - deny
+                    required:
+                    - operation
+                    - resource
+                type:
+                  type: string
+              required:
+              - acls
+          required:
+          - authentication

--- a/examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/examples/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: strimzi-user-operator
+    spec:
+      serviceAccountName: strimzi-user-operator
+      containers:
+        - name: strimzi-user-operator
+          image:  amqstreams-1-beta/amqstreams10-useroperator-openshift:1.0
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LABELS
+              value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_CA_NAME
+              value: my-cluster-clients-ca
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_ZOOKEEPER_CONNECT
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS
+              value: "20000"
+            - name: STRIMZI_LOG_LEVEL
+              value: INFO
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 500m
+            requests:
+              memory: 256Mi
+              cpu: 100m
+  strategy:
+    type: Recreate

--- a/examples/kafka-connect/kafka-connect-s2i.yaml
+++ b/examples/kafka-connect/kafka-connect-s2i.yaml
@@ -1,0 +1,19 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnectS2I
+metadata:
+  name: my-connect-cluster
+spec:
+  replicas: 1
+  readinessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  livenessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  metrics:
+    lowercaseOutputName: true
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt

--- a/examples/kafka-connect/kafka-connect.yaml
+++ b/examples/kafka-connect/kafka-connect.yaml
@@ -1,0 +1,19 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  replicas: 1
+  readinessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  livenessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  bootstrapServers: my-cluster-kafka-bootstrap:9093
+  metrics:
+    lowercaseOutputName: true
+  tls:
+    trustedCertificates:
+      - secretName: my-cluster-cluster-ca-cert
+        certificate: ca.crt

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -1,0 +1,46 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+    storage:
+      type: ephemeral
+    metrics:
+      lowercaseOutputName: true
+      rules:
+        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count"
+          name: "kafka_server_$1_$2_total"
+        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*, topic=(.+)><>Count"
+          name: "kafka_server_$1_$2_total"
+          labels:
+            topic: "$3"
+  zookeeper:
+    replicas: 3
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    storage:
+      type: ephemeral
+    metrics:
+      lowercaseOutputName: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -1,0 +1,51 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 3
+    listeners:
+      plain: {}
+      tls: {}
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: false
+    metrics:
+      lowercaseOutputName: true
+      rules:
+        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*><>Count"
+          name: "kafka_server_$1_$2_total"
+        - pattern: "kafka.server<type=(.+), name=(.+)PerSec\\w*, topic=(.+)><>Count"
+          name: "kafka_server_$1_$2_total"
+          labels:
+            topic: "$3"
+  zookeeper:
+    replicas: 3
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    storage:
+      type: persistent-claim
+      size: 1Gi
+      deleteClaim: false
+    metrics:
+      lowercaseOutputName: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/examples/templates/cluster-operator/connect-s2i-template.yaml
+++ b/examples/templates/cluster-operator/connect-s2i-template.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: strimzi-connect-s2i
+  annotations:
+    openshift.io/display-name: "Apache Kafka Connect S2I"
+    description: >-
+      This template installes Apache Kafka Connect in distributed mode together with build pipeline
+      for new Kafka Connect images with additional plugins. For more information about using this
+      template see http://strimzi.io
+    tags: "messaging"
+    iconClass: "fa fa-exchange"
+    template.openshift.io/documentation-url: "http://strimzi.io"
+message: "Kafka Connect S2I cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:8083' to access Kafka Connect REST API."
+parameters:
+- description: All Kubernetes resources will be named after the cluster name
+  displayName: Name of the cluster
+  name: CLUSTER_NAME
+  value: my-connect-cluster
+- description: Specifies the number of Kafka Connect instances to be started by default.
+  displayName: Number of Kafka Connect instances
+  name: INSTANCES
+  required: true
+  value: "1"
+- description: A list of host:port pairs to use for establishing the initial connection to the Kafka cluster.
+  displayName: Kafka bootstrap servers
+  name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
+  required: true
+  value: my-cluster-kafka-bootstrap:9092
+- description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
+  displayName: Group ID
+  name: KAFKA_CONNECT_GROUP_ID
+  required: true
+  value: "connect-cluster"
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Key Converter
+  name: KAFKA_CONNECT_KEY_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Set to false to use schemaless format
+  displayName: Enable schemas for key converters
+  name: KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+  value: "true"
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Value Converter
+  name: KAFKA_CONNECT_VALUE_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Set to false to use schemaless format
+  displayName: Enable schemas for value converters
+  name: KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+  value: "true"
+- description: Replication factor for config storage topic
+  displayName: Config replication factor
+  name: KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for offset storage topic
+  displayName: Offset replication factor
+  name: KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for status storage topic
+  displayName: Status replication factor
+  name: KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Kafka Connect healthcheck initial delay
+  name: HEALTHCHECK_DELAY
+  value: "60"
+- description: Number of seconds after which the probe times out.
+  displayName: Kafka Connect healthcheck timeout
+  name: HEALTHCHECK_TIMEOUT
+  value: "5"
+objects:
+- apiVersion: kafka.strimzi.io/v1alpha1
+  kind: KafkaConnectS2I
+  metadata:
+    name: ${CLUSTER_NAME}
+  spec:
+    replicas: ${{INSTANCES}}
+    livenessProbe:
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    readinessProbe:
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    bootstrapServers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
+    config:
+      group.id: "${KAFKA_CONNECT_GROUP_ID}"
+      offset.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-offsets"
+      config.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-configs"
+      status.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-status"
+      key.converter: "${KAFKA_CONNECT_KEY_CONVERTER}"
+      value.converter: "${KAFKA_CONNECT_VALUE_CONVERTER}"
+      key.converter.schemas.enable: ${{KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}}
+      value.converter.schemas.enable: ${{KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}}
+      config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
+      offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
+      status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
+    metrics:
+      lowercaseOutputName: true

--- a/examples/templates/cluster-operator/connect-template.yaml
+++ b/examples/templates/cluster-operator/connect-template.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: strimzi-connect
+  annotations:
+    openshift.io/display-name: "Apache Kafka Connect"
+    description: >-
+      This template installs Apache Kafka Connect in distributed mode. For more information
+      about using this template see http://strimzi.io
+    tags: "messaging"
+    iconClass: "fa fa-exchange"
+    template.openshift.io/documentation-url: "http://strimzi.io"
+message: "Kafka Connect cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:8083' to access Kafka Connect REST API."
+parameters:
+- description: All Kubernetes resources will be named after the cluster name
+  displayName: Name of the cluster
+  name: CLUSTER_NAME
+  value: my-connect-cluster
+- description: Specifies the number of Kafka Connect instances to be started by default.
+  displayName: Number of Kafka Connect instances
+  name: INSTANCES
+  required: true
+  value: "1"
+- description: A list of host:port pairs to use for establishing the initial connection to the Kafka cluster.
+  displayName: Kafka bootstrap servers
+  name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
+  required: true
+  value: my-cluster-kafka-bootstrap:9092
+- description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
+  displayName: Group ID
+  name: KAFKA_CONNECT_GROUP_ID
+  required: true
+  value: connect-cluster
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Key Converter
+  name: KAFKA_CONNECT_KEY_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Set to false to use schemaless format
+  displayName: Enable schemas for key converters
+  name: KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+  value: "true"
+- description: Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka.
+  displayName: Value Converter
+  name: KAFKA_CONNECT_VALUE_CONVERTER
+  required: true
+  value: org.apache.kafka.connect.json.JsonConverter
+- description: Set to false to use schemaless format
+  displayName: Enable schemas for value converters
+  name: KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+  value: "true"
+- description: Replication factor for config storage topic
+  displayName: Config replication factor
+  name: KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for offset storage topic
+  displayName: Offset replication factor
+  name: KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for status storage topic
+  displayName: Status replication factor
+  name: KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
+  value: "3"
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Kafka Connect healthcheck initial delay
+  name: HEALTHCHECK_DELAY
+  value: "60"
+- description: Number of seconds after which the probe times out.
+  displayName: Kafka Connect healthcheck timeout
+  name: HEALTHCHECK_TIMEOUT
+  value: "5"
+objects:
+- apiVersion: kafka.strimzi.io/v1alpha1
+  kind: KafkaConnect
+  metadata:
+    name: ${CLUSTER_NAME}
+  spec:
+    replicas: ${{INSTANCES}}
+    livenessProbe:
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    readinessProbe:
+      initialDelaySeconds: ${{HEALTHCHECK_DELAY}}
+      timeoutSeconds: ${{HEALTHCHECK_TIMEOUT}}
+    bootstrapServers: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
+    config:
+      group.id: "${KAFKA_CONNECT_GROUP_ID}"
+      offset.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-offsets"
+      config.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-configs"
+      status.storage.topic: "${KAFKA_CONNECT_GROUP_ID}-status"
+      key.converter: "${KAFKA_CONNECT_KEY_CONVERTER}"
+      value.converter: "${KAFKA_CONNECT_VALUE_CONVERTER}"
+      key.converter.schemas.enable: ${{KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}}
+      value.converter.schemas.enable: ${{KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}}
+      config.storage.replication.factor: ${{KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}}
+      offset.storage.replication.factor: ${{KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}}
+      status.storage.replication.factor: ${{KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}}
+    metrics:
+      lowercaseOutputName: true

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: strimzi-ephemeral
+  annotations:
+    openshift.io/display-name: "Apache Kafka (Ephemeral storage)"
+    description: >-
+      This template installs Apache Zookeeper and Apache Kafka clusters. For more information
+      about using this template see http://strimzi.io
+
+
+      WARNING: Any data stored will be lost upon pod destruction. Only use this
+      template for testing."
+    tags: "messaging,datastore"
+    iconClass: "fa fa-share-alt fa-flip-horizontal"
+    template.openshift.io/documentation-url: "http://strimzi.io"
+message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:9092' as bootstrap server in your application"
+parameters:
+- description: All Kubernetes resources will be named after the cluster name
+  displayName: Name of the cluster
+  name: CLUSTER_NAME
+  value: my-cluster
+- description: Number of Zookeeper cluster nodes which will be deployed (odd number of nodes is recommended)
+  displayName: Number of Zookeeper cluster nodes (odd number of nodes is recommended)
+  name: ZOOKEEPER_NODE_COUNT
+  required: true
+  value: "3"
+- description: Number of Kafka cluster nodes which will be deployed
+  displayName: Number of Kafka cluster nodes
+  name: KAFKA_NODE_COUNT
+  required: true
+  value: "3"
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Zookeeper healthcheck initial delay
+  name: ZOOKEEPER_HEALTHCHECK_DELAY
+  value: "15"
+- description: Number of seconds after which the probe times out.
+  displayName: Zookeeper healthcheck timeout
+  name: ZOOKEEPER_HEALTHCHECK_TIMEOUT
+  value: "5"
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Kafka healthcheck initial delay
+  name: KAFKA_HEALTHCHECK_DELAY
+  value: "15"
+- description: Number of seconds after which the probe times out.
+  displayName: Kafka healthcheck timeout
+  name: KAFKA_HEALTHCHECK_TIMEOUT
+  value: "5"
+- description: Default replication factor for newly created topics
+  displayName: Default replication factor
+  name: KAFKA_DEFAULT_REPLICATION_FACTOR
+  value: "1"
+- description: Replication factor for offsets topic
+  displayName: Offsets replication factor
+  name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for transactions state log topic
+  displayName: Transaction state replication factor
+  name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+  value: "3"
+objects:
+- apiVersion: kafka.strimzi.io/v1alpha1
+  kind: Kafka
+  metadata:
+    name: ${CLUSTER_NAME}
+  spec:
+    kafka:
+      replicas: ${{KAFKA_NODE_COUNT}}
+      listeners:
+        plain: {}
+        tls: {}
+      livenessProbe:
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
+      readinessProbe:
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
+      storage:
+        type: ephemeral
+      config:
+        default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
+        offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
+        transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
+    zookeeper:
+      replicas: ${{ZOOKEEPER_NODE_COUNT}}
+      livenessProbe:
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
+      readinessProbe:
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
+      storage:
+        type: ephemeral
+    entityOperator:
+      topicOperator: {}
+      userOperator: {}

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: strimzi-persistent
+  annotations:
+    openshift.io/display-name: "Apache Kafka (Persistent storage)"
+    description: >-
+      This template installs Apache Zookeeper and Apache Kafka clusters. For more information
+      about using this template see http://strimzi.io
+    tags: "messaging,datastore"
+    iconClass: "fa fa-share-alt fa-flip-horizontal"
+    template.openshift.io/documentation-url: "http://strimzi.io"
+message: "Kafka cluster ${CLUSTER_NAME} is being deployed. Use '${CLUSTER_NAME}:9092' as bootstrap server in your application."
+parameters:
+- description: All Kubernetes resources will be named after the cluster name
+  displayName: Name of the cluster
+  name: CLUSTER_NAME
+  value: my-cluster
+- description: Number of Zookeeper cluster nodes which will be deployed (odd number of nodes is recommended)
+  displayName: Number of Zookeeper cluster nodes (odd number of nodes is recommended)
+  name: ZOOKEEPER_NODE_COUNT
+  required: true
+  value: "3"
+- description: Number of Kafka cluster nodes which will be deployed
+  displayName: Number of Kafka cluster nodes
+  name: KAFKA_NODE_COUNT
+  required: true
+  value: "3"
+- description: Volume space available for Zookeeper data, e.g. 512Mi, 2Gi.
+  displayName: Zookeeper Volume Capacity
+  name: ZOOKEEPER_VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- description: Volume space available for Kafka data, e.g. 512Mi, 2Gi.
+  displayName: Kafka Volume Capacity
+  name: KAFKA_VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Zookeeper healthcheck initial delay
+  name: ZOOKEEPER_HEALTHCHECK_DELAY
+  value: "15"
+- description: Number of seconds after which the probe times out.
+  displayName: Zookeeper healthcheck timeout
+  name: ZOOKEEPER_HEALTHCHECK_TIMEOUT
+  value: "5"
+- description: Number of seconds after the container has started before healthcheck probes are initiated.
+  displayName: Kafka healthcheck initial delay
+  name: KAFKA_HEALTHCHECK_DELAY
+  value: "15"
+- description: Number of seconds after which the probe times out.
+  displayName: Kafka healthcheck timeout
+  name: KAFKA_HEALTHCHECK_TIMEOUT
+  value: "5"
+- description: Default replication factor for newly created topics
+  displayName: Default replication factor
+  name: KAFKA_DEFAULT_REPLICATION_FACTOR
+  value: "1"
+- description: Replication factor for offsets topic
+  displayName: Offsets replication factor
+  name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+  value: "3"
+- description: Replication factor for transactions state log topic
+  displayName: Transaction state replication factor
+  name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+  value: "3"
+objects:
+- apiVersion: kafka.strimzi.io/v1alpha1
+  kind: Kafka
+  metadata:
+    name: ${CLUSTER_NAME}
+  spec:
+    kafka:
+      replicas: ${{KAFKA_NODE_COUNT}}
+      listeners:
+        plain: {}
+        tls: {}
+      livenessProbe:
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
+      readinessProbe:
+        initialDelaySeconds: ${{KAFKA_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{KAFKA_HEALTHCHECK_TIMEOUT}}
+      storage:
+        type: "persistent-claim"
+        size: "${KAFKA_VOLUME_CAPACITY}"
+        deleteClaim: false
+      config:
+        default.replication.factor: ${KAFKA_DEFAULT_REPLICATION_FACTOR}
+        offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
+        transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
+    zookeeper:
+      replicas: ${{ZOOKEEPER_NODE_COUNT}}
+      livenessProbe:
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
+      readinessProbe:
+        initialDelaySeconds: ${{ZOOKEEPER_HEALTHCHECK_DELAY}}
+        timeoutSeconds: ${{ZOOKEEPER_HEALTHCHECK_TIMEOUT}}
+      storage:
+        type: persistent-claim
+        size: "${ZOOKEEPER_VOLUME_CAPACITY}"
+        deleteClaim: false
+    entityOperator:
+      topicOperator: {}
+      userOperator: {}

--- a/examples/templates/topic-operator/topic-template.yaml
+++ b/examples/templates/topic-operator/topic-template.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: strimzi-topic
+  annotations:
+    openshift.io/display-name: "Apache Kafka Topic"
+    description: >-
+      This template creates a "Topic ConfigMap". Used in conjunction with
+      the Strimzi topic operator this will create a corresponding
+      topic in a Strimzi Kafka cluster.
+      For more information about using this template see http://strimzi.io
+    tags: "messaging"
+    iconClass: "fa fa-exchange"
+    template.openshift.io/documentation-url: "http://strimzi.io"
+parameters:
+- name: CLUSTER_NAME
+  displayName: Name of the Kafka cluster
+  description: Specifies the name of the Kafka cluster in which the topic should be created.
+  required: true
+  value: my-cluster
+- name: TOPIC_NAME
+  displayName: Name of the topic
+  description: Specifies the name of the topic in the Kafka cluster. This should be a valid Kubernetes resource name.
+  required: true
+  value: my-topic
+- name: TOPIC_PARTITIONS
+  displayName: Number of partitions
+  description: The number of partitions in the created topic.
+  required: true
+  value: "1"
+- name: TOPIC_REPLICAS
+  displayName: Number of replicas
+  description: The number of replicas in the created topic.
+  required: true
+  value: "1"
+- name: TOPIC_CONFIG
+  displayName: Topic config
+  description: >-
+    The topic config as a JSON map, for example: { "retention.ms":"345600000" }
+    See https://kafka.apache.org/10/documentation/#topicconfigs for config key names and
+    value syntax.
+  required: true
+  value: "{}"
+objects:
+- apiVersion: kafka.strimzi.io/v1alpha1
+  kind: KafkaTopic
+  metadata:
+    name: ${TOPIC_NAME}
+    labels:
+      strimzi.io/cluster: "${CLUSTER_NAME}"
+  spec:
+    partitions: ${{TOPIC_PARTITIONS}}
+    replicas: ${{TOPIC_REPLICAS}}
+    config: ${{TOPIC_CONFIG}}

--- a/examples/topic/kafka-topic.yaml
+++ b/examples/topic/kafka-topic.yaml
@@ -1,0 +1,14 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaTopic
+metadata:
+  name: my-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824
+ 
+

--- a/examples/user/kafka-user.yaml
+++ b/examples/user/kafka-user.yaml
@@ -1,0 +1,50 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaUser
+metadata:
+  name: my-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Example consumer Acls for topic my-topic suing consumer group my-group
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Read
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"
+      - resource:
+          type: group
+          name: my-group
+          patternType: literal
+        operation: Read
+        host: "*"
+      # Example Producer Acls for topic my-topic
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Write
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Create
+        host: "*"
+      - resource:
+          type: topic
+          name: my-topic
+          patternType: literal
+        operation: Describe
+        host: "*"


### PR DESCRIPTION
(2) Second PR unit to review

Copied example directory from upstream. Then updated the image fields in the cluster operator deployment ( examples/install/cluster-operator/05-Deployment-strimzi-cluster-operator.yaml ) to point to AMQ Streams images. That should be the only difference from upstream

This will allow us to start the AMQ Streams Cluster Operator the same way we start a Strimzi Cluster Operator and allow us to reuse the upstream documentation. This also brings us a step closer to having downstream model upstream for the sake of easier maintenance. Let me know what you think